### PR TITLE
Update AKS version field to current supported versions

### DIFF
--- a/apis/definition.yaml
+++ b/apis/definition.yaml
@@ -45,10 +45,11 @@ spec:
                       description: Kubernetes version
                       type: string
                       enum:
-                        - "1.27.3"
-                        - "1.26.6"
-                        - "1.25.11"
-                      default: "1.27.3"
+                        - "1.29"
+                        - "1.28"
+                        - "1.27"
+                        - "1.26"
+                      default: "1.29"
                     nodes:
                       type: object
                       description: AKS node configuration parameters.

--- a/apis/definition.yaml
+++ b/apis/definition.yaml
@@ -49,7 +49,7 @@ spec:
                         - "1.28"
                         - "1.27"
                         - "1.26"
-                      default: "1.29"
+                      default: "1.28"
                     nodes:
                       type: object
                       description: AKS node configuration parameters.

--- a/examples/aks-xr.yaml
+++ b/examples/aks-xr.yaml
@@ -6,7 +6,7 @@ spec:
   parameters:
     id: configuration-azure-aks
     region: westus
-    version: "1.27.3"
+    version: "1.28"
     nodes:
       count: 1
       instanceType: Standard_B2s


### PR DESCRIPTION
Also, move to minor version names instead of patch version names.

### Description of your changes

The api definition had an enum with a limited set of patch-level versions for AKS. These are no longer supported versions in all regions. This PR moves the list to only specify the minor version, and updates the list to match the current set of available k8s versions.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Deployed the configuration into an Upbound control plane and provisioned an AKS cluster
