### PR TITLE
Enable workloadidentity

### DIFF
--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -43,6 +43,8 @@ spec:
                     - name: default
                   identity:
                     - type: SystemAssigned
+                  oidcIssuerEnabled: true
+                  workloadIdentityEnabled: true
             connectionDetails:
               - fromConnectionSecretKey: kubeconfig
                 name: kubeconfig
@@ -91,6 +93,38 @@ spec:
                     string:
                       fmt: '%s-akscluster'
                       type: Format
+              - type: ToCompositeFieldPath
+                fromFieldPath: status.atProvider.oidcIssuerUrl
+                policy:
+                  fromFieldPath: Optional
+                toFieldPath: status.aks.oidcUrl
+          - name: workloadIdentitySettings
+            base:
+              apiVersion: kubernetes.crossplane.io/v1alpha1
+              kind: Object
+              spec:
+                deletionPolicy: Orphan
+                forProvider:
+                  manifest:
+                    apiVersion: v1
+                    kind: ConfigMap
+                    metadata:
+                      namespace: default
+            patches:
+              - fromFieldPath: spec.parameters.id
+                toFieldPath: spec.providerConfigRef.name
+                type: FromCompositeFieldPath
+              - fromFieldPath: spec.parameters.id
+                toFieldPath: spec.forProvider.manifest.metadata.name
+                transforms:
+                  - string:
+                      fmt: '%s-workloadidentity-settings'
+                      type: Format
+                    type: string
+                type: FromCompositeFieldPath
+              - fromFieldPath: status.aks.oidcUrl
+                toFieldPath: spec.forProvider.manifest.data.oidc_url
+                type: FromCompositeFieldPath
 
           - name: providerConfigHelm
             base:


### PR DESCRIPTION
### Description of your changes
This PR sets workloadidentity and oidcissuer as enabled on the AKS cluster, and stores the OIDC issuer url into a configmap on the AKS cluster

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Deployed into Upbound-hosted control plane and provisioned an AKS cluster. 