### PR TITLE
Move KubernetesCluster to v1beta2

### DIFF
--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -35,14 +35,14 @@ spec:
         resources:
           - name: kubernetesCluster
             base:
-              apiVersion: containerservice.azure.upbound.io/v1beta1
+              apiVersion: containerservice.azure.upbound.io/v1beta2
               kind: KubernetesCluster
               spec:
                 forProvider:
                   defaultNodePool:
-                    - name: default
+                    name: default
                   identity:
-                    - type: SystemAssigned
+                    type: SystemAssigned
                   oidcIssuerEnabled: true
                   workloadIdentityEnabled: true
             connectionDetails:
@@ -72,16 +72,16 @@ spec:
                 toFieldPath: spec.forProvider.resourceGroupNameSelector.matchLabels[azure.platform.upbound.io/network-id]
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.parameters.id
-                toFieldPath: spec.forProvider.defaultNodePool[0].vnetSubnetIdSelector.matchLabels[azure.platform.upbound.io/network-id]
+                toFieldPath: spec.forProvider.defaultNodePool.vnetSubnetIdSelector.matchLabels[azure.platform.upbound.io/network-id]
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.parameters.id
                 toFieldPath: spec.forProvider.dnsPrefix
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.parameters.nodes.instanceType
-                toFieldPath: spec.forProvider.defaultNodePool[0].vmSize
+                toFieldPath: spec.forProvider.defaultNodePool.vmSize
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.parameters.nodes.count
-                toFieldPath: spec.forProvider.defaultNodePool[0].nodeCount
+                toFieldPath: spec.forProvider.defaultNodePool.nodeCount
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.writeConnectionSecretToRef.namespace
                 toFieldPath: spec.writeConnectionSecretToRef.namespace


### PR DESCRIPTION


### Description of your changes

Use v1beta2 version of KubernetesCluster API to work around issue described in https://github.com/crossplane-contrib/provider-upjet-aws/issues/975#issuecomment-1830351543. These fields are no longer arrays, so removed patches that assumed array formatting.

Fixes #

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Tested on a local build
