### PR TITLE
Deterministically select general subnet

### DIFF
--- a/functions/xaks/main.k
+++ b/functions/xaks/main.k
@@ -75,6 +75,7 @@ _composition = ObservedComposedResources {
                     vmSize = oxrParams.nodes.instanceType
                     vnetSubnetIdSelector.matchLabels = {
                         "azure.platform.upbound.io/network-id" = oxrParams.id
+                        "azure.platform.upbound.io/subnet-service-type" = "general"
                     }
                 }
                 dnsPrefix = oxrParams.id

--- a/tests/test-xaks/main.k
+++ b/tests/test-xaks/main.k
@@ -61,6 +61,7 @@ _items = [
                                 vnetSubnetIdSelector = {
                                     matchLabels = {
                                         "azure.platform.upbound.io/network-id" = "configuration-azure-aks"
+                                        "azure.platform.upbound.io/subnet-service-type" = "general"
                                     }
                                 }
                             }

--- a/upbound.yaml
+++ b/upbound.yaml
@@ -10,7 +10,7 @@ spec:
     version: "v1"
   - configuration: xpkg.upbound.io/upbound/configuration-azure-network
     # renovate: datasource=github-releases depName=upbound/configuration-azure-network
-    version: "v0.17.0"
+    version: "v0.18.0"
   - provider: xpkg.upbound.io/upbound/provider-helm
     version: "v0"
   - provider: xpkg.upbound.io/upbound/provider-kubernetes


### PR DESCRIPTION
To avoid potential conflicts and accidental selection of database subnet on higher platform-ref-azure level

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Deterministically select a general subnet.

Related to https://github.com/upbound/configuration-azure-network/pull/118

Fixes #

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

e2e together with https://github.com/upbound/configuration-azure-network/pull/118
