### PR TITLE
update network config to remove aks service conflict

### DIFF
--- a/examples/xaks/xnetwork.yaml
+++ b/examples/xaks/xnetwork.yaml
@@ -6,3 +6,5 @@ spec:
   parameters:
     id: configuration-azure-aks
     region: westus
+    addressRange: "10.1.0.0/16"
+    generalSubnetRange: "10.1.1.0/24"

--- a/tests/e2etest-xaks/main.k
+++ b/tests/e2etest-xaks/main.k
@@ -48,6 +48,8 @@ _items = [
                         parameters = {
                             id = "configuration-azure-aks"
                             region = "westus"
+                            addressRange = "10.1.0.0/16"
+                            generalSubnetRange = "10.1.1.0/24"
                         }
                     }
                 }


### PR DESCRIPTION

### Description of your changes

Running the examples in this repo will result in the following error during Cluster provisioning:

```
"message": "The specified service CIDR 10.0.0.0/16 is conflicted with an existing subnet CIDR 10.0.1.0/24. Please see https://aka.ms/aks/servicecidroverlap for how to fix the error.",
```

Update networking config to match platform settings: https://github.com/upbound/platform-ref-azure/blob/02c12daf4b54c588e4456e29f06f8122d3548010/functions/xcluster/main.k#L42

Fixes #

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
