### PR TITLE
feat: status, zones, 1.35 aks version

### DIFF
--- a/apis/aks/definition.yaml
+++ b/apis/aks/definition.yaml
@@ -63,9 +63,9 @@ spec:
                     type: string
                     enum:
                     - "1.35"
-                    - "1.32"
-                    - "1.33"
                     - "1.34"
+                    - "1.33"
+                    - "1.32"
                     default: "1.34"
                   nodes:
                     type: object

--- a/apis/aks/definition.yaml
+++ b/apis/aks/definition.yaml
@@ -62,6 +62,7 @@ spec:
                     description: Kubernetes version
                     type: string
                     enum:
+                    - "1.35"
                     - "1.32"
                     - "1.33"
                     - "1.34"
@@ -77,6 +78,11 @@ spec:
                         type: string
                         description: instance types associated with the Node Group.
                         default: Standard_B2s
+                      availabilityZones:
+                        type: array
+                        description: Optional list of availability zones to spread the default node pool across (e.g. ["1","2","3"]). When omitted, no zones are set. Immutable once set.
+                        items:
+                          type: string
                     required:
                     - count
                     - instanceType

--- a/apis/aks/definition.yaml
+++ b/apis/aks/definition.yaml
@@ -47,12 +47,12 @@ spec:
                     items:
                       type: string
                       enum:
-                        - "*"
-                        - Create
-                        - Observe
-                        - Update
-                        - Delete
-                        - LateInitialize
+                      - "*"
+                      - Create
+                      - Observe
+                      - Update
+                      - Delete
+                      - LateInitialize
                     default: ["*"]
                   providerConfigName:
                     description: Crossplane ProviderConfig to use for provisioning this resources

--- a/examples/aks/aks-zones.yaml
+++ b/examples/aks/aks-zones.yaml
@@ -1,0 +1,15 @@
+apiVersion: azure.platform.upbound.io/v1alpha1
+kind: AKS
+metadata:
+  name: configuration-azure-aks-zones
+  namespace: default
+spec:
+  parameters:
+    id: configuration-azure-aks-zones
+    region: westus
+    version: "1.35"
+    managementPolicies: ["*"]
+    nodes:
+      count: 1
+      instanceType: Standard_B2s
+      availabilityZones: ["1", "2", "3"]

--- a/functions/aks/main.k
+++ b/functions/aks/main.k
@@ -8,7 +8,12 @@ schema DefaultSpec:
     providerConfigRef: {str:str}
     forProvider: {str:str}
 
-oxr = aks.AKS {**option("params").oxr}
+# Strip spec.crossplane before typed construction: under up v0.50.0 the observed
+# composite carries spec.crossplane.resourceRefs as untyped dicts, which fails the
+# typed AKS schema's resourceRefs validation. This composition never reads
+# spec.crossplane, so dropping it is safe and keeps output byte-identical.
+_oxrRaw = option("params").oxr
+oxr = aks.AKS {**{k = v for k, v in _oxrRaw if k != "spec"}, **{"spec" = {k = v for k, v in (_oxrRaw?.spec or {}) if k != "crossplane"}}}
 dxr = option("params").dxr
 ocds = option("params").ocds
 
@@ -38,6 +43,10 @@ _items = [
         status = {
             aks = {
                 oidcUrl = ocds?.kubernetesCluster?.Resource?.status?.atProvider?.oidcIssuerUrl
+                clusterName = ocds?.kubernetesCluster?.Resource?.metadata?.name
+                nodes = {
+                    vmSize = ocds?.kubernetesCluster?.Resource?.status?.atProvider?.defaultNodePool?.vmSize
+                }
             }
         }
     }
@@ -53,6 +62,8 @@ _items = [
                     name = "default"
                     nodeCount = oxr.spec.parameters.nodes.count
                     vmSize = oxr.spec.parameters.nodes.instanceType
+                    if oxr.spec.parameters.nodes?.availabilityZones:
+                        zones = oxr.spec.parameters.nodes.availabilityZones
                     vnetSubnetIdSelector.matchLabels = {
                         "azure.platform.upbound.io/network-id" = oxr.spec.parameters.id
                         "azure.platform.upbound.io/subnet-service-type" = "general"

--- a/tests/test-aks/main.k
+++ b/tests/test-aks/main.k
@@ -44,7 +44,7 @@ _items = [
                                 controller = True
                                 kind = "AKS"
                                 name = "configuration-azure-aks"
-                                uid = ""
+                                uid = "41fc1f8b-15d0-5034-be10-0ed93726503c"
                             }
                         ]
                     }
@@ -102,7 +102,7 @@ _items = [
                                 controller = True
                                 kind = "AKS"
                                 name = "configuration-azure-aks"
-                                uid = ""
+                                uid = "41fc1f8b-15d0-5034-be10-0ed93726503c"
                             }
                         ]
                     }
@@ -134,7 +134,7 @@ _items = [
                                 controller = True
                                 kind = "AKS"
                                 name = "configuration-azure-aks"
-                                uid = ""
+                                uid = "41fc1f8b-15d0-5034-be10-0ed93726503c"
                             }
                         ]
                     }
@@ -157,6 +157,7 @@ _items = [
                         labels = {
                             "crossplane.io/composite" = "configuration-azure-aks"
                         }
+                        name = "configuration-azure-aks-d7b3b1c32862"
                         namespace = "default"
                         ownerReferences = [
                             {
@@ -165,7 +166,7 @@ _items = [
                                 controller = True
                                 kind = "AKS"
                                 name = "configuration-azure-aks"
-                                uid = ""
+                                uid = "41fc1f8b-15d0-5034-be10-0ed93726503c"
                             }
                         ]
                     }
@@ -190,6 +191,110 @@ _items = [
             ]
             compositionPath: "apis/aks/composition.yaml"
             xrPath: "examples/aks/aks.yaml"
+            xrdPath: "apis/aks/definition.yaml"
+            timeoutSeconds: 60
+            validate: False
+        }
+    }
+    metav1alpha1.CompositionTest{
+        metadata.name: "test-status-propagation"
+        spec = {
+            observedResources: [
+                containerservicev1beta1.KubernetesCluster{
+                    metadata = {
+                        annotations = {
+                            "crossplane.io/composition-resource-name" = "kubernetesCluster"
+                        }
+                        labels = {
+                            "crossplane.io/composite" = "configuration-azure-aks"
+                        }
+                        name = "configuration-azure-aks-aks"
+                        namespace = "default"
+                    }
+                    spec = {
+                        forProvider = {
+                            defaultNodePool = {
+                                name = "default"
+                                nodeCount = 1
+                                vmSize = "Standard_B2s"
+                            }
+                        }
+                    }
+                    status = {
+                        atProvider = {
+                            oidcIssuerUrl = "https://westus.oic.prod-aks.azure.com/example/"
+                            defaultNodePool = {
+                                vmSize = "Standard_B2s"
+                            }
+                        }
+                    }
+                }
+            ]
+            assertResources: [
+                upazurev1alpha1.AKS{
+                    metadata = {
+                        name = "configuration-azure-aks"
+                        namespace = "default"
+                    }
+                    spec = {
+                        parameters = {
+                            id = "configuration-azure-aks"
+                            nodes = {
+                                count = 1
+                                instanceType = "Standard_B2s"
+                            }
+                            region = "westus"
+                            version = "1.34"
+                            managementPolicies = ["*"]
+                        }
+                    }
+                    status = {
+                        aks = {
+                            clusterName = "configuration-azure-aks-aks"
+                            oidcUrl = "https://westus.oic.prod-aks.azure.com/example/"
+                            nodes = {
+                                vmSize = "Standard_B2s"
+                            }
+                        }
+                    }
+                }
+            ]
+            compositionPath: "apis/aks/composition.yaml"
+            xrPath: "examples/aks/aks.yaml"
+            xrdPath: "apis/aks/definition.yaml"
+            timeoutSeconds: 60
+            validate: False
+        }
+    }
+    metav1alpha1.CompositionTest{
+        metadata.name: "test-availability-zones"
+        spec = {
+            assertResources: [
+                containerservicev1beta1.KubernetesCluster{
+                    metadata = {
+                        annotations = {
+                            "crossplane.io/composition-resource-name" = "kubernetesCluster"
+                        }
+                        labels = {
+                            "crossplane.io/composite" = "configuration-azure-aks-zones"
+                        }
+                        name = "configuration-azure-aks-zones-aks"
+                        namespace = "default"
+                    }
+                    spec = {
+                        forProvider = {
+                            defaultNodePool = {
+                                name = "default"
+                                nodeCount = 1
+                                vmSize = "Standard_B2s"
+                                zones = ["1", "2", "3"]
+                            }
+                        }
+                    }
+                }
+            ]
+            compositionPath: "apis/aks/composition.yaml"
+            xrPath: "examples/aks/aks-zones.yaml"
             xrdPath: "apis/aks/definition.yaml"
             timeoutSeconds: 60
             validate: False

--- a/tests/test-aks/main.k
+++ b/tests/test-aks/main.k
@@ -4,6 +4,10 @@ import models.io.upbound.azurem.containerservice.v1beta1 as containerservicev1be
 import models.io.upbound.dev.meta.v1alpha1 as metav1alpha1
 import models.io.upbound.platform.azure.v1alpha1 as upazurev1alpha1
 
+# Shared owner-reference uid for observed-resource fixtures: up v0.50.0 assigns
+# the composite a deterministic uid, and owner refs must match it.
+_ownerUid = "41fc1f8b-15d0-5034-be10-0ed93726503c"
+
 _items = [
     metav1alpha1.CompositionTest{
         metadata.name: "test-happy-path"
@@ -44,7 +48,7 @@ _items = [
                                 controller = True
                                 kind = "AKS"
                                 name = "configuration-azure-aks"
-                                uid = "41fc1f8b-15d0-5034-be10-0ed93726503c"
+                                uid = _ownerUid
                             }
                         ]
                     }
@@ -102,7 +106,7 @@ _items = [
                                 controller = True
                                 kind = "AKS"
                                 name = "configuration-azure-aks"
-                                uid = "41fc1f8b-15d0-5034-be10-0ed93726503c"
+                                uid = _ownerUid
                             }
                         ]
                     }
@@ -134,7 +138,7 @@ _items = [
                                 controller = True
                                 kind = "AKS"
                                 name = "configuration-azure-aks"
-                                uid = "41fc1f8b-15d0-5034-be10-0ed93726503c"
+                                uid = _ownerUid
                             }
                         ]
                     }
@@ -166,7 +170,7 @@ _items = [
                                 controller = True
                                 kind = "AKS"
                                 name = "configuration-azure-aks"
-                                uid = "41fc1f8b-15d0-5034-be10-0ed93726503c"
+                                uid = _ownerUid
                             }
                         ]
                     }


### PR DESCRIPTION
### Description of your changes

Extends the `AKS` XR so higher-level configurations (e.g. `configuration-azure-ctp`)
can read cluster metadata from the XR status, spread nodes across availability zones, and select Kubernetes 1.35. 
All changes are additive and backward-compatible.