### PR TITLE
fix: align provider-kubernetes dependency to floating v1

### DIFF
--- a/upbound.yaml
+++ b/upbound.yaml
@@ -27,7 +27,7 @@ spec:
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider
     package: xpkg.upbound.io/upbound/provider-kubernetes
-    version: v1.1.0
+    version: v1
   description: Azure AKS Configuration is reusable Configuration designed to be primarily
     used in higher level Configurations.
   license: Apache-2.0


### PR DESCRIPTION
### Description of your changes

Change the `provider-kubernetes` dependency pin in `upbound.yaml` from the concrete `v1.1.0` to the floating major `v1`.